### PR TITLE
Fix --account-key option

### DIFF
--- a/bin/logentries
+++ b/bin/logentries
@@ -102,7 +102,7 @@ def main(account_key, host, log, start, end, filter_string):
         return 2
 
     url = URL_TEMPLATE.format(
-        account_key=os.environ['LOGENTRIES_ACCOUNT_KEY'],
+        account_key=account_key,
         host=host,
         log=log,
     )


### PR DESCRIPTION
The following currently fails:

```
logentries logset log -k AKEY
Traceback (most recent call last):
  File "/usr/local/bin/logentries", line 204, in <module>
    sys.exit(main(**kwargs))
  File "/usr/local/bin/logentries", line 105, in main
    account_key=os.environ['LOGENTRIES_ACCOUNT_KEY'],
  File "/usr/lib/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: u'LOGENTRIES_ACCOUNT_KEY'
```
